### PR TITLE
feat: introduced a way to pass origin header casing hashmap to hyper

### DIFF
--- a/src/client/legacy/client.rs
+++ b/src/client/legacy/client.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{self, Poll};
 use std::time::Duration;
+use std::collections::HashMap;
 
 use futures_util::future::{self, Either, FutureExt, TryFutureExt};
 use http::uri::Scheme;
@@ -1214,6 +1215,14 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_title_case_headers(&mut self, val: bool) -> &mut Self {
         self.h1_builder.title_case_headers(val);
+        self
+    }
+
+    /// Set origin header names to be used in HTTP/1 connections.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+    pub fn http1_origin_header_names(&mut self, val: HashMap<String, String>) -> &mut Self {
+        self.h1_builder.origin_header_names(val);
         self
     }
 


### PR DESCRIPTION
This PR introduces a way to pass a hashmap to hyper for using as origin header casing